### PR TITLE
Allow persistent gyro calibration values and disable continuous learning

### DIFF
--- a/RTIMULib/IMUDrivers/RTIMU.cpp
+++ b/RTIMULib/IMUDrivers/RTIMU.cpp
@@ -214,7 +214,7 @@ bool RTIMU::setGyroContinuousLearningAlpha(RTFLOAT alpha)
 void RTIMU::gyroBiasInit()
 {
     m_gyroLearningAlpha = 2.0f / m_sampleRate;
-    m_gyroContinuousAlpha = 0.01f / m_sampleRate;
+    m_gyroContinuousAlpha = 0.0f / m_sampleRate;
     m_gyroSampleCount = 0;
 }
 
@@ -280,7 +280,7 @@ void RTIMU::handleGyroBias()
     deltaAccel -= m_imuData.accel;   // compute difference
     m_previousAccel = m_imuData.accel;
 
-    if ((deltaAccel.length() < RTIMU_FUZZY_ACCEL_ZERO) && (m_imuData.gyro.length() < RTIMU_FUZZY_GYRO_ZERO)) {
+    if ((deltaAccel.length() < RTIMU_FUZZY_ACCEL_ZERO) && (m_imuData.gyro.length() < RTIMU_FUZZY_GYRO_ZERO) && (m_settings->m_gyroBiasValid == false)) {
         // what we are seeing on the gyros should be bias only so learn from this
 
         if (m_gyroSampleCount < (5 * m_sampleRate)) {


### PR DESCRIPTION
The gyroscope kept overwriting its calibration values, and this was a problem for robots that cannot be still when the library is started up (i.e. underwater robots that are set up on sea waves).

As I see it, once the variable _GyroBiasValid_ is set to _true_ in the configuration, nothing should change the calibrated values. This is achieved completing the if statement with the condition _m_settings->m_gyroBiasValid == false_

I also faced the problem that the python bindings don't have a way of changing the continuous gyro calibration learning, so I've changed the default from 0.01 to 0 (no on-line learning).