### PR TITLE
Permit ellipsoid fit calibration to be run from anywhere

### DIFF
--- a/Linux/RTIMULibCal/RTIMULibCal.cpp
+++ b/Linux/RTIMULibCal/RTIMULibCal.cpp
@@ -34,7 +34,7 @@
 
 //  where to find the ellipsoid fitting code
 
-#define ELLIPSOID_FIT_DIR               "../RTEllipsoidFit/"
+#define ELLIPSOID_FIT_DIR               RTIMUCALDEFS_OCTAVE_PATH
 
 //  function prototypes
 
@@ -234,7 +234,7 @@ void doMagEllipsoidCal()
             magCal->newEllipsoidData(imuData.compass);
 
             if (magCal->magCalEllipsoidValid()) {
-                magCal->magCalSaveRaw(ELLIPSOID_FIT_DIR);
+                magCal->magCalSaveRaw(".");
                 processEllipsoid();
                 return;
             }
@@ -268,7 +268,6 @@ void processEllipsoid()
     pid = fork();
     if (pid == 0) {
         //  child process
-        chdir(ELLIPSOID_FIT_DIR);
         execl("/bin/sh", "/bin/sh", "-c", RTIMUCALDEFS_OCTAVE_COMMAND, NULL);
         printf("here");
         _exit(EXIT_FAILURE);
@@ -282,7 +281,7 @@ void processEllipsoid()
         } else {
             if (status == 0) {
                 printf("\nEllipsoid fit completed - saving data to file.");
-                magCal->magCalSaveCorr(ELLIPSOID_FIT_DIR);
+                magCal->magCalSaveCorr(".");
             } else {
                 printf("\nEllipsoid fit returned %d - aborting.\n", status);
             }

--- a/Linux/RTIMULibDemo/MagCalDlg.cpp
+++ b/Linux/RTIMULibDemo/MagCalDlg.cpp
@@ -38,9 +38,7 @@ MagCalDlg::MagCalDlg(QWidget *parent, RTIMUSettings* settings)
     m_cal = new RTIMUMagCal(settings);
     m_newData = false;
 
-    m_fitDirOptions.append("./RTEllipsoidFit/");
-    m_fitDirOptions.append("../RTEllipsoidFit/");
-    m_fitDirOptions.append("../../RTEllipsoidFit/");
+    m_fitDirOptions.append(RTIMUCALDEFS_OCTAVE_PATH);
 
     findFitDir();
 
@@ -121,15 +119,14 @@ void MagCalDlg::onSaveMinMax()
 
 void MagCalDlg::onProcess()
 {
-    m_cal->magCalSaveRaw(qPrintable(m_fitDir));
+    m_cal->magCalSaveRaw(".");
 
     QProcess proc;
 
-    proc.setWorkingDirectory(m_fitDir);
     proc.start(RTIMUCALDEFS_OCTAVE_COMMAND);
     proc.waitForFinished(20000);
     if (proc.exitCode() == 0) {
-        m_cal->magCalSaveCorr(qPrintable(m_fitDir));
+        m_cal->magCalSaveCorr(".");
     } else {
         QMessageBox::warning(this, "Ellipsoid fit error",
             "Failed to execute RTEllipsoidFit.m. Only min/max calibration available",

--- a/RTIMULib/RTIMUCalDefs.h
+++ b/RTIMULib/RTIMUCalDefs.h
@@ -51,7 +51,8 @@
 #define RTIMUCALDEFS_MAG_RAW_FILE          "magRaw.dta"     // the raw sample file - input to ellispoid fit code
 #define RTIMUCALDEFS_MAG_CORR_FILE         "magCorr.dta"    // the output from the ellipsoid fit code
 
+#define RTIMUCALDEFS_OCTAVE_PATH           "/usr/share/librtimulib-utils/RTEllipsoidFit"
 #define RTIMUCALDEFS_OCTAVE_CODE           "RTEllipsoidFit.m"
-#define RTIMUCALDEFS_OCTAVE_COMMAND        "octave RTEllipsoidFit.m"
+#define RTIMUCALDEFS_OCTAVE_COMMAND        "octave --path " RTIMUCALDEFS_OCTAVE_PATH " " RTIMUCALDEFS_OCTAVE_PATH "/" RTIMUCALDEFS_OCTAVE_CODE
 
 #endif // RTIMUCALDEFS_H


### PR DESCRIPTION
By default, the ellipsoid fit calculations require that the matlab/octave files are present in the working directory *and* that the user has write access to the working directory. In practice this means either the user must be root or the user must copy the matlab/octave files to their working directory before beginning calibration.

This patch simply adds the package's installation path to the octave path to enable non-root users to perform calibration from any directory they have write access to (such as their home directory).