### PR TITLE
Update the minimum to one compatible with modern cmake

### DIFF
--- a/Linux/CMakeLists.txt
+++ b/Linux/CMakeLists.txt
@@ -38,7 +38,7 @@ INCLUDE(FeatureSummary)
 ########################################################################
 # Project setup
 ########################################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 PROJECT(RTIMULib CXX)
 ENABLE_TESTING()
 

--- a/RTHost/CMakeLists.txt
+++ b/RTHost/CMakeLists.txt
@@ -35,7 +35,7 @@ ENDIF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 ########################################################################
 # Project setup
 ########################################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 PROJECT(RTIMUHOST CXX)
 ENABLE_TESTING()
 

--- a/RTIMULib/CMakeLists.txt
+++ b/RTIMULib/CMakeLists.txt
@@ -35,7 +35,7 @@ ENDIF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 ########################################################################
 # Project setup
 ########################################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 PROJECT(RTIMULib CXX)
 ENABLE_TESTING()
 


### PR DESCRIPTION
Modern versions of cmake no longer operate with CMAKE_MINIMUM_REQUIRED at 2.8.9. Update to 3.5 which is the new minimum accepted; no other changes to the files appear to be necessary.